### PR TITLE
fix: Add Athena insert to macros [DATA-794]

### DIFF
--- a/macros/_macros.yml
+++ b/macros/_macros.yml
@@ -57,107 +57,7 @@ macros:
     description: |
       Dependent on the adapter type, returns the native type for storing JSON.
 
-  ## MIGRATION ##
-  - name: migrate_from_v0_to_v1
-    description: |
-      A macro to assist with migrating from v0 to v1 of dbt_artifacts. See
-      https://github.com/brooklyn-data/dbt_artifacts/blob/main/README.md#migrating-from-100-to-100
-      for details on the usage.
-    arguments:
-      - name: old_database
-        type: string
-        description: |
-          The database of the <1.0.0 output (fct_/dim_) models - does not have to be different to `new_database`
-      - name: old_schema
-        type: string
-        description: |
-          The schema of the <1.0.0 output (fct_/dim_) models - does not have to be different to `new_schema`
-      - name: new_database
-        type: string
-        description: |
-          The target database that the v1 artifact sources are in - does not have to be different to `old_database`
-      - name: new_schema
-        type: string
-        description: |
-          The target schema that the v1 artifact sources are in - does not have to be different to `old_schema`
-
   ## UPLOAD INDIVIDUAL DATASETS ##
-  - name: upload_exposures
-    description: |
-      The macro to support upload of the data to the exposures table.
-    arguments:
-      - name: exposures
-        type: list
-        description: |
-          A list of exposure objects extracted from the dbt graph
-
-  - name: upload_invocations
-    description: |
-      The macro to support upload of the data to the invocations table.
-
-  - name: upload_model_executions
-    description: |
-      The macro to support upload of the data to the model_executions table.
-    arguments:
-      - name: models
-        type: list
-        description: |
-          A list of model execution results objects extracted from the dbt result object
-
-  - name: upload_models
-    description: |
-      The macro to support upload of the data to the models table.
-    arguments:
-      - name: models
-        type: list
-        description: |
-          A list of test objects extracted from the dbt graph
-
-  - name: upload_seed_executions
-    description: |
-      The macro to support upload of the data to the seed_executions table.
-    arguments:
-      - name: seeds
-        type: list
-        description: |
-          A list of seed execution results objects extracted from the dbt result object
-
-  - name: upload_seeds
-    description: |
-      The macro to support upload of the data to the seeds table.
-    arguments:
-      - name: seeds
-        type: list
-        description: |
-          A list of seeds objects extracted from the dbt graph
-
-  - name: upload_snapshot_executions
-    description: |
-      The macro to support upload of the data to the snapshot_executions table.
-    arguments:
-      - name: snapshots
-        type: list
-        description: |
-          A list of snapshot execution results objects extracted from the dbt result object
-
-  - name: upload_snapshots
-    description: |
-      The macro to support upload of the data to the snapshots table.
-    arguments:
-      - name: snapshots
-        type: list
-        description: |
-          A list of snapshots objects extracted from the dbt graph
-
-  - name: upload_sources
-    description: |
-      The macro to support upload of the data to the sources table.
-    arguments:
-      - name: sources
-        type: list
-        description: |
-          A list of sources objects extracted from the dbt graph
-
   - name: upload_test_executions
     description: |
       The macro to support upload of the data to the test_executions table.
@@ -166,15 +66,6 @@ macros:
         type: list
         description: |
           A list of test execution results objects extracted from the dbt result object
-
-  - name: upload_tests
-    description: |
-      The macro to support upload of the data to the tests table.
-    arguments:
-      - name: tests
-        type: list
-        description: |
-          A list of test objects extracted from the dbt graph
 
   ## UPLOAD RESULTS ##
   - name: get_column_name_list

--- a/macros/upload_results/insert_into_metadata_table.sql
+++ b/macros/upload_results/insert_into_metadata_table.sql
@@ -11,6 +11,17 @@
 
 {%- endmacro %}
 
+{% macro athena__insert_into_metadata_table(relation, fields, content) -%}
+
+    {% set insert_into_table_query %}
+    insert into {{ relation }} {{ fields }}
+    {{ content }}
+    {% endset %}
+
+    {% do run_query(insert_into_table_query) %}
+
+{%- endmacro %}
+
 {% macro spark__insert_into_metadata_table(relation, fields, content) -%}
 
     {% set insert_into_table_query %}


### PR DESCRIPTION
### What does it do? Why?

* Add back the macro to insert data into dbt_artifacts models
* Delete removed macros from the documentation