### PR TITLE
chore: Bump maximum version of dbt to migrate to 1.10 easily [FTTECH-2778]

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: "dbt_artifacts"
 version: "2.8.0"
 config-version: 2
-require-dbt-version: [">=1.3.0", "<1.10.0"]
+require-dbt-version: [">=1.3.0", "<2.0.0"]
 profile: "dbt_artifacts"
 
 clean-targets: # folders to be removed by `dbt clean`


### PR DESCRIPTION
### What does it do? Why?

* Bump maximum version of dbt to be compatible with our custom dbt artifact