### PR TITLE
feat: Remove extra endmacro tag in macro file [FTTECH-2784]

### DIFF
--- a/macros/upload_results/insert_into_metadata_table.sql
+++ b/macros/upload_results/insert_into_metadata_table.sql
@@ -56,8 +56,6 @@
 
 {%- endmacro %}
 
-{%- endmacro %}
-
 {% macro postgres__insert_into_metadata_table(relation, fields, content) -%}
 
     {% set insert_into_table_query %}


### PR DESCRIPTION
### What does it do? Why?

* Remove extra tag that causes warning in dbt v1.10